### PR TITLE
jenkins-job.sh: Add support for pinephone, tenderloin, qemux86(-64) a…

### DIFF
--- a/jenkins-job.sh
+++ b/jenkins-job.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BUILD_SCRIPT_VERSION="2.5.28"
+BUILD_SCRIPT_VERSION="2.5.29"
 BUILD_SCRIPT_NAME=`basename ${0}`
 
 pushd `dirname $0` > /dev/null
@@ -424,7 +424,7 @@ function run_update-manifest() {
         echo "Updating device image manifest for testing for machines ${SUPPORTED_MACHINES}"
         wget http://build.webos-ports.org/luneos-testing/device-images.json -O device-images.json
         for machine in ${SUPPORTED_MACHINES} ; do
-            image_path=`ssh jenkins@milla.nao find /home2/jenkins/htdocs/builds/luneos-testing/images/$machine -type f -name 'luneos-dev-package-$machine*' ! -name 'luneos-dev-package-$machine.zip' ! -name '*.md5' | sort -r | head -n 1`
+            image_path=`ssh jenkins@milla.nao find /home2/jenkins/htdocs/builds/luneos-testing/images/$machine -type f -name 'luneos-dev-package-$machine*' ! -name 'luneos-dev-package-$machine.zip' ! -name 'luneos-dev-image-$machine*.gz' ! -name 'luneos-dev-emulator-$machine*.gz' ! -name '*.md5' | sort -r | head -n 1`
             if [ -z "$image_path" ] ; then
                 echo "Couldn't find image for machine $machine"
                 exit 1


### PR DESCRIPTION
…nd raspberrypi2/3(-64) images.

v 2.5.29:
device-images.json is used by the update service to check for available images. Currently it will only populate with mako images. The script needs adjusting to allow for the pinephone, tenderloing, qemux86(-64) and raspberrypi images to be included as well.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>