### PR TITLE
jenkins-jobs.sh: Build halium 9.0 for mido as well (v2.6.37)

### DIFF
--- a/jenkins-job.sh
+++ b/jenkins-job.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BUILD_SCRIPT_VERSION="2.6.36"
+BUILD_SCRIPT_VERSION="2.6.37"
 BUILD_SCRIPT_NAME=`basename ${0}`
 
 pushd `dirname $0` > /dev/null
@@ -612,10 +612,9 @@ function run_halium {
     if [[ "${BUILD_VERSION}" = "7.1" ]] ; then
         halium_build_device onyx lineage_onyx-userdebug
     elif [[ "${BUILD_VERSION}" = "9.0" ]] ; then
-        # Disable mido build for now, since manifest is missing (needs checking and pushing)
-        # halium_build_device mido lineage_mido-userdebug
         halium_build_device hammerhead lineage_hammerhead-userdebug
         halium_build_device mako lineage_mako-userdebug
+        halium_build_device mido lineage_mido-userdebug
         halium_build_device rosy lineage_rosy-userdebug
         halium_build_device tenderloin lineage_tenderloin-userdebug
         halium_build_device tissot lineage_tissot-userdebug


### PR DESCRIPTION
Building halium 9.0 for mido with kernel 4.9 now works as well.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>